### PR TITLE
[design] 기존 home UI 전면 개편

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import ServerSearchForm from '@/components/ServerSearchForm';
-import KoreanStandardTime from '@/components/KoreanStandaradTime';
+import Header from '@/components/ui/Header';
+import SearchForm from '@/components/ServerSearchForm';
 import { useRouter } from 'next/navigation';
+import KoreanStandardTime from '@/components/KoreanStandaradTime';
 
 export default function Home() {
   const router = useRouter();
@@ -12,20 +13,35 @@ export default function Home() {
   };
 
   return (
-    <main className="flex min-h-screen flex-col bg-primary items-center justify-center px-4">
-      <h1 className="text-5xl font-bold text-brand-blue-500">Check Time</h1>
-      <h2 className="mt-4 text-2xl font-semibold text-black">
-        지금, 서버 시간은 몇시인가요?
-      </h2>
+    <div className="min-h-screen bg-gray-50 text-gray-900">
+      {/* Header */}
+      <Header />
 
-      <div className="mt-8 w-full max-w-2xl">
-        {/* 검색 input + 버튼 */}
-        <ServerSearchForm onSubmit={handleSubmit} />
-      </div>
-      <div className="mt-8 max-w-3xl w-full">
-        {/* 한국 표준 시간 컴포넌트 */}
-        <KoreanStandardTime />
-      </div>
-    </main>
+      {/* Hero */}
+      <section className="text-center py-16">
+        <div className="inline-flex items-center gap-2 bg-indigo-100 text-indigo-600 text-sm font-medium px-3 py-1 rounded-full mb-6">
+          ✨ 정확한 서버 시간 확인 서비스
+        </div>
+        <h1 className="text-6xl md:text-5xl font-bold tracking-tight bg-gradient-to-br from-black to-gray-600 text-transparent bg-clip-text mb-6">
+          티켓팅 성공을 위한
+          <br />
+          정확한 시간 동기화
+        </h1>
+        <p className="text-gray-600 text-lg max-w-2xl mx-auto leading-relaxed">
+          서버와의 시간 차이를 실시간으로 확인하고, 완벽한 타이밍으로 티켓팅에
+          성공하세요.
+        </p>
+      </section>
+
+      {/* URL Input */}
+      <section className="max-w-xl mx-auto">
+        <SearchForm onSubmit={handleSubmit} />
+      </section>
+
+      {/* Current Time */}
+      <section className="max-w-3xl mx-auto mb-20 p-10">
+        <KoreanStandardTime showToggle={false} />
+      </section>
+    </div>
   );
 }

--- a/src/components/KoreanStandaradTime.tsx
+++ b/src/components/KoreanStandaradTime.tsx
@@ -4,8 +4,10 @@ import { useEffect, useState } from 'react';
 
 export default function KoreanStandardTime({
   showMilliseconds = true,
+  showToggle = true, // 밀리초 체크박스 표시 여부
 }: {
   showMilliseconds?: boolean;
+  showToggle?: boolean;
 }) {
   const [time, setTime] = useState<Date | null>(null);
 
@@ -64,7 +66,7 @@ export default function KoreanStandardTime({
       </div>
 
       <div className="text-center">
-        <div className="flex items-center justify-center gap-4 text-6xl font-bold text-gray-800">
+        <div className="flex items-center justify-center gap-4 text-5xl font-bold text-gray-800">
           {(() => {
             const [h, m, s, ms] = formatTime(time).split(/[:.]/);
             return (
@@ -78,24 +80,27 @@ export default function KoreanStandardTime({
                   <>
                     <span className="text-gray-400">:</span>
                     <span className="text-4xl">{ms}</span>
+
+                    {showToggle && (
+                      <span className="flex items-center text-xl text-gray-500 ml-2 gap-2">
+                        밀리초
+                        <input
+                          type="checkbox"
+                          checked={showMilliseconds}
+                          onChange={(e) =>
+                            typeof window !== 'undefined' &&
+                            document.dispatchEvent(
+                              new CustomEvent('toggleMilliseconds', {
+                                detail: e.target.checked,
+                              }),
+                            )
+                          }
+                          className="w-4 h-4"
+                        />
+                      </span>
+                    )}
                   </>
                 )}
-                <span className="flex items-center text-2xl text-gray-500 ml-2 gap-2">
-                  밀리초
-                  <input
-                    type="checkbox"
-                    checked={showMilliseconds}
-                    onChange={(e) =>
-                      typeof window !== 'undefined' &&
-                      document.dispatchEvent(
-                        new CustomEvent('toggleMilliseconds', {
-                          detail: e.target.checked,
-                        }),
-                      )
-                    }
-                    className="w-4 h-4"
-                  />
-                </span>
               </>
             );
           })()}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -9,7 +9,7 @@ export const Button = React.forwardRef<
     <button
       ref={ref}
       className={clsx(
-        'px-4 py-2 rounded-md font-semibold text-white bg-brand-blue-500 hover:bg-brand-blue-700 active:bg-brand-blue-900 transition-colors',
+        'px-6 py-4 rounded-md font-semibold bg-indigo-500 hover:bg-indigo-600 text-white transition-colors',
         className,
       )}
       {...props}

--- a/src/components/ui/Header.tsx
+++ b/src/components/ui/Header.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import clsx from 'clsx';
+
+export default function Header() {
+  const [scrolled, setScrolled] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setScrolled(window.scrollY > 100);
+    };
+
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  return (
+    <header
+      className={clsx(
+        'sticky top-0 z-50 backdrop-blur transition-colors duration-300',
+        scrolled
+          ? 'bg-white/95 border-b border-black/10'
+          : 'bg-white/80 border-b border-black/5',
+      )}
+    >
+      <div className="max-w-7xl mx-auto flex items-center justify-between px-6 py-3">
+        {/* 로고 */}
+        <Link
+          href="/"
+          className="flex items-center gap-2 text-black font-semibold text-base"
+        >
+          <div className="w-7 h-7 rounded-md flex items-center justify-center text-white text-sm bg-gradient-to-br from-indigo-400 to-purple-500">
+            ⏰
+          </div>
+          Check Time
+        </Link>
+
+        {/* 네비게이션 */}
+        <nav className="hidden md:flex items-center gap-8 text-sm text-gray-600 font-medium">
+          <Link href="#" className="hover:text-black transition-colors">
+            실시간 랭킹
+          </Link>
+          <Link href="#" className="hover:text-black transition-colors">
+            반응속도 게임
+          </Link>
+          <Link href="#" className="hover:text-black transition-colors">
+            북마크
+          </Link>
+          <Link href="#" className="hover:text-black transition-colors">
+            도움말
+          </Link>
+        </nav>
+
+        {/* 액션 버튼 */}
+        <div className="flex items-center gap-3">
+          <Link
+            href="#"
+            className="text-gray-600 hover:bg-gray-100 px-4 py-2 rounded-md text-sm transition-colors"
+          >
+            로그인
+          </Link>
+          <Link
+            href="#"
+            className="bg-black text-white hover:bg-black/80 px-4 py-2 rounded-md text-sm transition"
+          >
+            시작하기
+          </Link>
+        </div>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## 📌 작업 내용
- home의 UI를 redesign 했습니다. (v2)
- KoreanStandardTime 컴포넌트의 밀리초 체크박스에 옵션을 추가했습니다.  
- 따라서 home에서 밀리초 체크박스가 표시되지 않습니다. 

## 📸 스크린샷
<img width="2568" height="1526" alt="image" src="https://github.com/user-attachments/assets/613527bb-cda6-4918-9bcd-12558822bcc0" />

## 📝 기타
Header 내 메뉴 항목(실시간 랭킹, 반응속도 게임, 북마크, 도움말)에 대해 현재는 href="#"로 임시 연결되어 있으며, 각 기능 페이지가 개발되는 시점에 맞춰 실제 경로로 변경할 계획입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 새로운 헤더 컴포넌트가 추가되어 상단에 고정된 내비게이션 바와 로그인/시작하기 버튼이 제공됩니다.
  * 메인 페이지 레이아웃이 개선되어 배지, 그라데이션 텍스트, 설명 문구 등 시각적으로 강화된 히어로 섹션이 도입되었습니다.

* **개선 및 스타일**
  * 버튼의 크기와 색상이 조정되어 더욱 눈에 띄고 사용하기 쉬워졌습니다.
  * 페이지 전체의 배경색과 텍스트 색상이 변경되어 시각적 일관성이 향상되었습니다.

* **기능 개선**
  * 한국 표준시 컴포넌트에 밀리초 토글 표시 여부를 제어할 수 있는 옵션이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->