### PR TITLE
[feature] 실시간 순위 페이지 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "clsx": "^2.1.1",
-        "lucide-react": "^0.525.0",
+        "lucide-react": "^0.544.0",
         "next": "^15.4.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -18,13 +18,13 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3",
         "@types/node": "^20",
-        "@types/react": "^19",
-        "@types/react-dom": "^19",
+        "@types/react": "^19.1.13",
+        "@types/react-dom": "^19.1.9",
         "autoprefixer": "^10.4.21",
         "eslint": "^9",
         "eslint-config-next": "15.3.5",
         "postcss": "^8.5.6",
-        "typescript": "^5"
+        "typescript": "^5.9.2"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -177,9 +177,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.35.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.35.0.tgz",
-      "integrity": "sha512-30iXE9whjlILfWobBkNerJo+TXYsgVM5ERQwMcMKCHckHflCmf7wXDAHlARoWnh0s1U72WqlbeyE7iAcCzuCPw==",
+      "version": "9.36.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.36.0.tgz",
+      "integrity": "sha512-uhCbYtYynH30iZErszX78U+nR3pJU3RHGQ57NXy5QupD4SBVwDeU8TNBy+MjMngc1UyIW9noKqsRqfjQTBU2dw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1013,9 +1013,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.16.tgz",
-      "integrity": "sha512-VS6TTONVdgwJwtJr7U+ghEjpfmQdqehLLpg/iMYGOd1+ilaFjdBJwFuPggJ4EAYPDCzWfDUHoIxyVnu+tOWVuQ==",
+      "version": "20.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.17.tgz",
+      "integrity": "sha512-gfehUI8N1z92kygssiuWvLiwcbOB3IRktR6hTDgJlXMYh5OvkPSRmgfoBUmfZt+vhwJtX7v1Yw4KvvAf7c5QKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1966,9 +1966,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.4.tgz",
-      "integrity": "sha512-L+YvJwGAgwJBV1p6ffpSTa2KRc69EeeYGYjRVWKs0GKrK+LON0GC0gV+rKSNtALEDvMDqkvCFq9r1r94/Gjwxw==",
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.6.tgz",
+      "integrity": "sha512-wrH5NNqren/QMtKUEEJf7z86YjfqW/2uw3IL3/xpqZUC95SSVIFXYQeeGjL6FT/X68IROu6RMehZQS5foy2BXw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2447,9 +2447,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.220",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.220.tgz",
-      "integrity": "sha512-TWXijEwR1ggr4BdAKrb1nMNqYLTx1/4aD1fkeZU+FVJGTKu53/T7UyHKXlqEX3Ub02csyHePbHmkvnrjcaYzMA==",
+      "version": "1.5.222",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.222.tgz",
+      "integrity": "sha512-gA7psSwSwQRE60CEoLz6JBCQPIxNeuzB2nL8vE03GK/OHxlvykbLyeiumQy1iH5C2f3YbRAZpGCMT12a/9ih9w==",
       "dev": true,
       "license": "ISC"
     },
@@ -2660,9 +2660,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.35.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.35.0.tgz",
-      "integrity": "sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==",
+      "version": "9.36.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.36.0.tgz",
+      "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2672,7 +2672,7 @@
         "@eslint/config-helpers": "^0.3.1",
         "@eslint/core": "^0.15.2",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.35.0",
+        "@eslint/js": "9.36.0",
         "@eslint/plugin-kit": "^0.3.5",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -4277,9 +4277,9 @@
       "license": "ISC"
     },
     "node_modules/lucide-react": {
-      "version": "0.525.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.525.0.tgz",
-      "integrity": "sha512-Tm1txJ2OkymCGkvwoHt33Y2JpN5xucVq1slHcgE6Lk0WjDfjgKWor5CdVER8U6DvcfMwh4M8XxmpTiyzfmfDYQ==",
+      "version": "0.544.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.544.0.tgz",
+      "integrity": "sha512-t5tS44bqd825zAW45UQxpG2CvcC4urOwn2TrwSH8u+MjeE+1NnWl6QqeQ/6NdjMqdOygyiT9p3Ev0p1NJykxjw==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "clsx": "^2.1.1",
-    "lucide-react": "^0.525.0",
+    "lucide-react": "^0.544.0",
     "next": "^15.4.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
@@ -19,12 +19,12 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@types/node": "^20",
-    "@types/react": "^19",
-    "@types/react-dom": "^19",
+    "@types/react": "^19.1.13",
+    "@types/react-dom": "^19.1.9",
     "autoprefixer": "^10.4.21",
     "eslint": "^9",
     "eslint-config-next": "15.3.5",
     "postcss": "^8.5.6",
-    "typescript": "^5"
+    "typescript": "^5.9.2"
   }
 }

--- a/src/app/bookmarks/page.tsx
+++ b/src/app/bookmarks/page.tsx
@@ -189,10 +189,30 @@ export default function BookmarksPage() {
           </Link>
           
           <nav className="flex items-center gap-8">
-            <a href="#" className="text-gray-600 text-sm font-medium hover:text-black transition-colors no-underline">실시간 랭킹</a>
-            <a href="#" className="text-gray-600 text-sm font-medium hover:text-black transition-colors no-underline">반응속도 게임</a>
-            <a href="/bookmarks" className="text-black text-sm font-semibold no-underline">북마크</a>
-            <a href="#" className="text-gray-600 text-sm font-medium hover:text-black transition-colors no-underline">도움말</a>
+            <a
+              href="/ranking"
+              className="text-gray-600 text-sm font-medium hover:text-black transition-colors no-underline"
+            >
+              실시간 랭킹
+            </a>
+            <a
+              href="/reaction-test"
+              className="text-gray-600 text-sm font-medium hover:text-black transition-colors no-underline"
+            >
+              반응속도 게임
+            </a>
+            <a
+              href="/bookmarks"
+              className="text-black text-sm font-semibold no-underline"
+            >
+              북마크
+            </a>
+            <a
+              href="/help"
+              className="text-gray-600 text-sm font-medium hover:text-black transition-colors no-underline"
+            >
+              도움말
+            </a>
           </nav>
           
           <div className="flex items-center gap-3">

--- a/src/app/ranking/page.tsx
+++ b/src/app/ranking/page.tsx
@@ -38,13 +38,6 @@ export default function RankingPage() {
         category: activeCategory,
       });
 
-      // 중복된 site_id가 있는지 검사합니다.
-      // const ids = fetchedSites.map((s) => s.site_id);
-      // const duplicates = ids.filter((id, index) => ids.indexOf(id) !== index);
-      // if (duplicates.length > 0) {
-      //   console.log('🚨 중복된 site_id가 발견되었습니다:', duplicates);
-      // }
-
       setSites(fetchedSites);
     } catch (err) {
       setError(

--- a/src/app/ranking/page.tsx
+++ b/src/app/ranking/page.tsx
@@ -1,0 +1,232 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { getPopularSites, Site } from '@/libs/api/popularSites';
+import { EmptyState } from '@/components/RankingEmptyState';
+
+// 랭크(1,2,3위)에 따라 뱃지 색상을 반환하는 헬퍼 함수
+const getRankBadgeStyle = (rank: number): React.CSSProperties => {
+  if (rank === 1) return { backgroundColor: '#FFD700' };
+  if (rank === 2) return { backgroundColor: '#C0C0C0' };
+  if (rank === 3) return { backgroundColor: '#CD7F32' };
+  return { backgroundColor: '#f0f0f0', color: '#333' };
+};
+
+export default function RankingPage() {
+  const [sites, setSites] = useState<Site[]>([]);
+
+  const [period, setPeriod] = useState<'realtime' | 'daily' | 'weekly' | 'all'>(
+    'realtime',
+  );
+
+  // 기간 옵션들
+  const periods: (typeof period)[] = ['realtime', 'daily', 'weekly', 'all'];
+
+  const [activeCategory, setActiveCategory] = useState<string>('전체');
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const categories = ['전체', '티켓팅', '대학교'];
+
+  const fetchSites = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      // API 함수를 호출하고, 파라미터를 객체 형태로 전달
+      const fetchedSites = await getPopularSites({
+        period,
+        category: activeCategory,
+      });
+
+      // 중복된 site_id가 있는지 검사합니다.
+      // const ids = fetchedSites.map((s) => s.site_id);
+      // const duplicates = ids.filter((id, index) => ids.indexOf(id) !== index);
+      // if (duplicates.length > 0) {
+      //   console.log('🚨 중복된 site_id가 발견되었습니다:', duplicates);
+      // }
+
+      setSites(fetchedSites);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : '알 수 없는 오류가 발생했습니다.',
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [period, activeCategory]);
+
+  // 컴포넌트가 처음 렌더링되거나, 필터가 변경될 때 API를 호출
+  useEffect(() => {
+    fetchSites();
+  }, [fetchSites]);
+
+  return (
+    <div style={{ background: '#f8f9fa', minHeight: '100vh', padding: '2rem' }}>
+      <div style={{ maxWidth: '800px', margin: '0 auto' }}>
+        {/* 헤더 */}
+        <header style={{ textAlign: 'center', marginBottom: '2rem' }}>
+          <h1 style={{ fontSize: '2.5rem', fontWeight: 'bold' }}>
+            🚀 실시간 인기 링크 순위
+          </h1>
+          <p
+            style={{
+              color: '#6c757d',
+              fontSize: '1.1rem',
+              marginTop: '0.5rem',
+            }}
+          >
+            지금 가장 많이 검색되는 티켓팅 사이트를 확인하세요.
+          </p>
+          <p style={{ color: '#adb5bd', fontSize: '0.9rem' }}></p>
+        </header>
+
+        {/* 카테고리 필터 */}
+        <nav
+          style={{
+            display: 'flex',
+            justifyContent: 'center',
+            gap: '0.5rem',
+            marginBottom: '2rem',
+          }}
+        >
+          {categories.map((cat) => (
+            <button
+              key={cat}
+              onClick={() => setActiveCategory(cat)}
+              style={{
+                padding: '0.75rem 1.5rem',
+                border: 'none',
+                borderRadius: '999px',
+                cursor: 'pointer',
+                fontSize: '1rem',
+                fontWeight: 'bold',
+                background: activeCategory === cat ? '#212529' : '#fff',
+                color: activeCategory === cat ? '#fff' : '#212529',
+                boxShadow: '0 2px 4px rgba(0,0,0,0.05)',
+              }}
+            >
+              {cat}
+            </button>
+          ))}
+        </nav>
+
+        {/* 기간(period) 필터 */}
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'flex-end',
+            gap: '0.5rem',
+            marginBottom: '0.5rem',
+          }}
+        >
+          {periods.map((p) => (
+            <button
+              key={p}
+              onClick={() => setPeriod(p)}
+              style={{
+                padding: '0.25rem 0.75rem',
+                border: '1px solid #dee2e6',
+                borderRadius: '6px',
+                cursor: 'pointer',
+                fontSize: '0.8rem',
+                background: period === p ? '#2a2e45' : '#fff',
+                color: period === p ? '#fff' : '#212529',
+              }}
+            >
+              {p.charAt(0).toUpperCase() + p.slice(1)}
+            </button>
+          ))}
+        </div>
+
+        {/* 랭킹 리스트 */}
+        <main>
+          {loading ? (
+            <p style={{ textAlign: 'center' }}>로딩 중...</p>
+          ) : error ? (
+            <p style={{ textAlign: 'center', color: 'red' }}>오류: {error}</p>
+          ) : sites.length > 0 ? (
+            <div
+              style={{
+                background: '#fff',
+                borderRadius: '12px',
+                boxShadow: '0 4px 12px rgba(0,0,0,0.1)',
+                padding: '1rem',
+              }}
+            >
+              <ol style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+                {sites.map((site, index) => (
+                  <li
+                    key={site.site_id}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      padding: '1.5rem 1rem',
+                      borderBottom:
+                        index < sites.length - 1 ? '1px solid #f1f3f5' : 'none',
+                    }}
+                  >
+                    {/* 순위 뱃지 */}
+                    <div
+                      style={{
+                        ...getRankBadgeStyle(index + 1),
+                        width: '36px',
+                        height: '36px',
+                        borderRadius: '50%',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        fontWeight: 'bold',
+                        fontSize: '1rem',
+                        marginRight: '1rem',
+                      }}
+                    >
+                      {index + 1}
+                    </div>
+
+                    {/* 사이트 정보 */}
+                    <div style={{ flex: 1, marginRight: '1rem' }}>
+                      <span
+                        style={{
+                          fontSize: '1.1rem',
+                          fontWeight: 'bold',
+                          display: 'block',
+                          marginBottom: '0.25rem',
+                        }}
+                      >
+                        {site.name}
+                      </span>
+                      <a
+                        href={site.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        style={{
+                          color: '#868e96',
+                          textDecoration: 'none',
+                          fontSize: '0.9rem',
+                        }}
+                      >
+                        {site.url}
+                      </a>
+                    </div>
+
+                    {/* 검색 횟수 */}
+                    <div style={{ textAlign: 'right' }}>
+                      <div style={{ fontSize: '1.5rem', fontWeight: 'bold' }}>
+                        {parseInt(site.click_count, 10).toLocaleString()}
+                      </div>
+                      <div style={{ fontSize: '0.9rem', color: '#868e96' }}>
+                        검색 횟수
+                      </div>
+                    </div>
+                  </li>
+                ))}
+              </ol>
+            </div>
+          ) : (
+            <EmptyState />
+          )}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/app/ranking/page.tsx
+++ b/src/app/ranking/page.tsx
@@ -156,7 +156,7 @@ export default function RankingPage() {
               <ol style={{ listStyle: 'none', padding: 0, margin: 0 }}>
                 {sites.map((site, index) => (
                   <li
-                    key={site.site_id}
+                    key={site.id}
                     style={{
                       display: 'flex',
                       alignItems: 'center',

--- a/src/components/ClientHeader.tsx
+++ b/src/components/ClientHeader.tsx
@@ -5,10 +5,16 @@ import Header from '@/components/ui/Header';
 import LoginModal from './auth/LoginModal';
 import SignupModal from './auth/SignupModal';
 import ConfirmModal from '@/components/ui/ConfirmModal';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 
 export default function ClientHeader() {
   const router = useRouter();
+
+  const pathname = usePathname();
+  const HIDE_ON = ['/bookmarks'];
+  const hideHeader = HIDE_ON.some(
+    (p) => pathname === p || pathname.startsWith(p + '/'),
+  );
 
   // 전역 헤더 상태
   const [isAuthed, setIsAuthed] = useState(false);
@@ -120,15 +126,16 @@ export default function ClientHeader() {
   return (
     <>
       {/* 헤더 */}
-      {isAuthed ? (
-        <Header
-          isAuthed
-          userName={userName ?? ''}
-          onLogoutClick={() => setConfirmOpen(true)}
-        />
-      ) : (
-        <Header onLoginClick={() => setLoginOpen(true)} />
-      )}
+      {!hideHeader &&
+        (isAuthed ? (
+          <Header
+            isAuthed
+            userName={userName ?? ''}
+            onLogoutClick={() => setConfirmOpen(true)}
+          />
+        ) : (
+          <Header onLoginClick={() => setLoginOpen(true)} />
+        ))}
 
       {/* 로그인 모달 */}
       <LoginModal

--- a/src/components/RankingEmptyState.tsx
+++ b/src/components/RankingEmptyState.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+// 데이터 없음을 안내하는 UI 컴포넌트
+export const EmptyState = () => {
+  return (
+    <div
+      style={{
+        textAlign: 'center',
+        padding: '4rem 2rem',
+        backgroundColor: '#fff',
+        borderRadius: '12px',
+        boxShadow: '0 4px 12px rgba(0,0,0,0.1)',
+      }}
+    >
+      <span style={{ fontSize: '4rem' }}>텅~</span>
+      <h2 style={{ marginTop: '1rem', fontWeight: 'bold' }}>
+        아직 집계된 기록이 없어요
+      </h2>
+      <p style={{ color: '#6c757d', fontSize: '1rem' }}>
+        사용자들이 사이트를 검색하면 이곳에 실시간 순위가 표시됩니다.
+      </p>
+    </div>
+  );
+};

--- a/src/components/ui/Header.tsx
+++ b/src/components/ui/Header.tsx
@@ -52,7 +52,7 @@ export default function Header(props: HeaderProps) {
 
         {/* 네비게이션 */}
         <nav className="hidden md:flex items-center gap-8 text-sm text-gray-600 font-medium">
-          <Link href="#" className="hover:text-black transition-colors">
+          <Link href="/ranking" className="hover:text-black transition-colors">
             실시간 랭킹
           </Link>
           <Link

--- a/src/libs/api/popularSites.ts
+++ b/src/libs/api/popularSites.ts
@@ -1,5 +1,5 @@
 export interface Site {
-  site_id: number;
+  id: number;
   name: string;
   url: string;
   category: string;

--- a/src/libs/api/popularSites.ts
+++ b/src/libs/api/popularSites.ts
@@ -24,7 +24,10 @@ export const getPopularSites = async ({
   period,
   category,
 }: FetchParams): Promise<Site[]> => {
-  const BASE_URL = 'http://localhost:3001/api/sites/popular/popular-sites';
+  const BASE_URL = `${process.env.NEXT_PUBLIC_API_BASE}/api/sites/popular/popular-sites`;
+  if (!process.env.NEXT_PUBLIC_API_BASE) {
+    throw new Error('환경변수 NEXT_PUBLIC_API_BASE가 설정되지 않았습니다.');
+  }
 
   const params = new URLSearchParams({
     period,
@@ -38,11 +41,13 @@ export const getPopularSites = async ({
 
   try {
     // API 요청
-    const response = await fetch(`${BASE_URL}?${params.toString()}`);
+    const url = `${BASE_URL}?${params.toString()}`;
+    const response = await fetch(url, { cache: 'no-store' });
 
-    // HTTP 응답 상태가 'ok'가 아니면 에러를 발생시킴
     if (!response.ok) {
-      throw new Error('네트워크 응답에 문제가 있습니다.');
+      throw new Error(
+        `네트워크 오류: ${response.status} ${response.statusText}`,
+      );
     }
 
     const result: ApiResponse = await response.json();

--- a/src/libs/api/popularSites.ts
+++ b/src/libs/api/popularSites.ts
@@ -1,0 +1,59 @@
+export interface Site {
+  site_id: number;
+  name: string;
+  url: string;
+  category: string;
+  click_count: string;
+}
+
+interface ApiResponse {
+  success: boolean;
+  data: {
+    period: string;
+    category: string;
+    sites: Site[];
+  };
+}
+
+interface FetchParams {
+  period: 'realtime' | 'daily' | 'weekly' | 'all';
+  category: string;
+}
+
+export const getPopularSites = async ({
+  period,
+  category,
+}: FetchParams): Promise<Site[]> => {
+  const BASE_URL = 'http://localhost:3001/api/sites/popular/popular-sites';
+
+  const params = new URLSearchParams({
+    period,
+    limit: '10',
+  });
+
+  // '전체' 카테고리가 아닐 경우에만 파라미터를 추가
+  if (category !== '전체') {
+    params.append('category', category);
+  }
+
+  try {
+    // API 요청
+    const response = await fetch(`${BASE_URL}?${params.toString()}`);
+
+    // HTTP 응답 상태가 'ok'가 아니면 에러를 발생시킴
+    if (!response.ok) {
+      throw new Error('네트워크 응답에 문제가 있습니다.');
+    }
+
+    const result: ApiResponse = await response.json();
+
+    if (!result.success) {
+      throw new Error('API에서 데이터를 가져오지 못했습니다.');
+    }
+
+    return result.data.sites;
+  } catch (error) {
+    console.error('인기 사이트 API 연동 중 오류 발생:', error);
+    throw error;
+  }
+};


### PR DESCRIPTION
실시간 인기 사이트 랭킹을 조회할 수 있는 페이지를 구현했습니다.
사용자는 기간 및 카테고리별로 인기 사이트 목록을 필터링하여 확인할 수 있습니다. 

## 📌 작업 내용
- 인기 사이트 순위 목록 UI 구현
- 기간(Period) 및 카테고리(Category)별 필터링 기능 추가
- 데이터 없음 상태에 대한 UI 처리

### 🛠️ 변경 사항
- API 응답 데이터의 식별자 키(`id`) 불일치로 인한 렌더링 오류 수정 🐞 
- 북마크 페이지에서 전역 헤더 숨김 (ClientHeader 조건부 렌더링) 

## 📸 스크린샷
<img width="2544" height="1308" alt="image" src="https://github.com/user-attachments/assets/7d6018f8-148e-4106-9028-5a7ecb2d4023" /> 
<img width="2514" height="1520" alt="image" src="https://github.com/user-attachments/assets/481881a1-f148-462d-adb5-a073ea690911" />

## 📝 기타
텅~


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * 실시간 랭킹 페이지 추가: 기간·카테고리 필터, 순위 배지, 검색 횟수 표시, 로딩/에러 처리, 빈 상태 표시 지원.
  * 내비게이션 개선: 랭킹(/ranking), 반응속도 게임, 도움말 등 실제 경로로 연결.
  * 헤더 표시 제어: 북마크 및 하위 경로에서 헤더 숨김.

* Chores
  * 의존성 업데이트: lucide-react, @types/react, @types/react-dom, typescript 버전 상향.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->